### PR TITLE
Add Lidarr backup plugin

### DIFF
--- a/backend/app/plugins/lidarr/__init__.py
+++ b/backend/app/plugins/lidarr/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import LidarrPlugin
+
+__all__ = ["LidarrPlugin"]

--- a/backend/app/plugins/lidarr/plugin.py
+++ b/backend/app/plugins/lidarr/plugin.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import httpx
+from app.core.plugins.base import BackupContext, BackupPlugin
+import logging
+
+
+class LidarrPlugin(BackupPlugin):
+    """Lidarr backup plugin using Servarr API.
+
+    Research notes:
+    - The Lidarr UI exposes a Backup section allowing manual and scheduled backups.
+    - Documentation describes manual backups via System ➜ Backup and restoring from zip archives.
+    - The underlying API uses the Servarr command endpoint to trigger a backup and exposes
+      existing backups through `/api/v1/system/backup`.
+    - Backups include the app's configuration directory, which lives under paths such as
+      `/config` when running in Docker.
+    """
+
+    def __init__(self, name: str, version: str = "0.1.0") -> None:
+        super().__init__(name=name, version=version)
+        self._logger = logging.getLogger(__name__)
+
+    async def validate_config(self, config: Dict[str, Any]) -> bool:  # pragma: no cover - trivial
+        if not isinstance(config, dict):
+            return False
+        base_url = config.get("base_url")
+        api_key = config.get("api_key")
+        if not base_url or not isinstance(base_url, str):
+            return False
+        if not api_key or not isinstance(api_key, str):
+            return False
+        return True
+
+    async def test(self, config: Dict[str, Any]) -> bool:
+        """Check connectivity to Lidarr using provided API key."""
+        if not await self.validate_config(config):
+            return False
+        base_url = str(config.get("base_url", "")).rstrip("/")
+        api_key = config.get("api_key")
+        status_url = f"{base_url}/api/v1/system/status"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(status_url, headers={"X-Api-Key": str(api_key)})
+                if resp.status_code // 100 != 2:
+                    self._logger.warning(
+                        "lidarr_test_non_2xx | url=%s status=%s", status_url, resp.status_code
+                    )
+                    return False
+        except httpx.HTTPError as exc:
+            self._logger.warning("lidarr_test_error | url=%s error=%s", status_url, exc)
+            return False
+        return True
+
+    async def backup(self, context: BackupContext) -> Dict[str, Any]:
+        meta = context.metadata or {}
+        target_slug = meta.get("target_slug") or str(context.target_id)
+        today = datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d")
+        base_dir = os.path.join("/backups", target_slug, today)
+        os.makedirs(base_dir, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).astimezone().strftime("%Y%m%dT%H%M%S")
+        artifact_path = os.path.join(base_dir, f"lidarr-backup-{timestamp}.zip")
+
+        cfg = context.config or {}
+        base_url = str(cfg.get("base_url", "")).rstrip("/")
+        api_key = cfg.get("api_key")
+        if not base_url or not api_key:
+            raise ValueError("Lidarr config must include base_url and api_key")
+
+        command_url = f"{base_url}/api/v1/command"
+        backup_list_url = f"{base_url}/api/v1/system/backup"
+        headers = {"X-Api-Key": str(api_key)}
+
+        async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+            # Trigger a backup via the command endpoint
+            try:
+                await client.post(command_url, json={"name": "Backup"}, headers=headers)
+            except httpx.HTTPError as exc:
+                self._logger.error(
+                    "lidarr_backup_command_error | job_id=%s target_id=%s error=%s",
+                    context.job_id,
+                    context.target_id,
+                    exc,
+                )
+                raise
+
+            # Retrieve list of backups and pick the most recent one
+            resp = await client.get(backup_list_url, headers=headers)
+            resp.raise_for_status()
+            backups: List[Dict[str, Any]] = resp.json() if resp.content else []
+            if not backups:
+                raise RuntimeError("Lidarr backup list empty")
+            latest = sorted(backups, key=lambda b: b.get("time", ""), reverse=True)[0]
+            backup_id = latest.get("id")
+            if backup_id is None:
+                raise RuntimeError("Latest backup lacks id")
+
+            download_url = f"{backup_list_url}/{backup_id}"
+            dl_resp = await client.get(download_url, headers=headers)
+            dl_resp.raise_for_status()
+            with open(artifact_path, "wb") as fh:
+                fh.write(dl_resp.content)
+
+        return {"artifact_path": artifact_path}
+
+    async def restore(self, context: BackupContext) -> Dict[str, Any]:  # pragma: no cover - not implemented
+        return {"status": "not_implemented"}
+
+    async def get_status(self, context: BackupContext) -> Dict[str, Any]:  # pragma: no cover - trivial
+        return {"status": "ok"}

--- a/backend/app/plugins/lidarr/schema.json
+++ b/backend/app/plugins/lidarr/schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "required": ["base_url", "api_key"],
+  "properties": {
+    "base_url": {
+      "type": "string",
+      "format": "uri",
+      "title": "Base URL",
+      "default": "http://lidarr.local:8686"
+    },
+    "api_key": {
+      "type": "string",
+      "title": "API Key",
+      "default": "your_api_key"
+    }
+  }
+}

--- a/backend/tests/test_lidarr_plugin.py
+++ b/backend/tests/test_lidarr_plugin.py
@@ -1,0 +1,69 @@
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+
+from app.core.plugins.base import BackupContext
+from app.plugins.lidarr import LidarrPlugin
+
+
+@pytest.mark.asyncio
+async def test_lidarr_validate_and_test(monkeypatch):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/api/v1/system/status"):
+            return httpx.Response(200, json={"version": "1"})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    orig_client = httpx.AsyncClient
+
+    def _client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return orig_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _client)
+
+    plugin = LidarrPlugin(name="lidarr")
+    cfg = {"base_url": "http://example.local", "api_key": "abc"}
+    assert await plugin.validate_config(cfg) is True
+    assert await plugin.test(cfg) is True
+
+
+@pytest.mark.asyncio
+async def test_lidarr_backup_writes_artifact(monkeypatch):
+    backups = [
+        {"id": 1, "time": "2024-01-01T00:00:00Z"},
+        {"id": 2, "time": "2024-01-02T00:00:00Z"},
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/api/v1/command") and request.method == "POST":
+            return httpx.Response(200, json={"id": 1})
+        if request.url.path.endswith("/api/v1/system/backup") and request.method == "GET":
+            return httpx.Response(200, json=backups)
+        if request.url.path.endswith("/api/v1/system/backup/2") and request.method == "GET":
+            return httpx.Response(200, content=b"zipdata")
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    orig_client = httpx.AsyncClient
+
+    def _client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return orig_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _client)
+
+    plugin = LidarrPlugin(name="lidarr")
+    ctx = BackupContext(
+        job_id="1",
+        target_id="1",
+        config={"base_url": "http://example.local", "api_key": "abc"},
+        metadata={"target_slug": "lidarr"},
+    )
+    result = await plugin.backup(ctx)
+    artifact_path = result.get("artifact_path")
+    assert artifact_path and os.path.exists(artifact_path)
+    assert artifact_path.endswith('.zip')


### PR DESCRIPTION
## Summary
- add Lidarr plugin implementing backup via Servarr command and backup endpoints
- provide JSON schema for base URL and API key configuration
- include tests for configuration, connectivity, and artifact creation

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fd2e699c8326a34a4379bed5a634