### PR TITLE
feat: add Jellyfin backup plugin

### DIFF
--- a/backend/app/plugins/jellyfin/__init__.py
+++ b/backend/app/plugins/jellyfin/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import JellyfinPlugin
+
+__all__ = ["JellyfinPlugin"]

--- a/backend/app/plugins/jellyfin/plugin.py
+++ b/backend/app/plugins/jellyfin/plugin.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import httpx
+import logging
+
+from app.core.plugins.base import BackupContext, BackupPlugin
+
+BACKUP_BASE = "/backups"
+
+
+class JellyfinPlugin(BackupPlugin):
+    """Jellyfin backup plugin using the Backup plugin API.
+
+    Research notes:
+    - Jellyfin exposes an optional Backup plugin that can generate a ZIP archive
+      of server configuration and metadata.
+    - API access uses an administrator API key supplied via the `X-Emby-Token` header.
+    - `GET /System/Info` is a lightweight connectivity check.
+    - `GET /Backup/Archive` streams a ZIP archive of the backup.
+    """
+
+    def __init__(self, name: str, version: str = "0.1.0") -> None:
+        super().__init__(name=name, version=version)
+        self._logger = logging.getLogger(__name__)
+
+    async def validate_config(self, config: Dict[str, Any]) -> bool:  # pragma: no cover - trivial
+        if not isinstance(config, dict):
+            return False
+        base_url = config.get("base_url")
+        api_key = config.get("api_key")
+        if not base_url or not isinstance(base_url, str):
+            return False
+        if not api_key or not isinstance(api_key, str):
+            return False
+        return True
+
+    async def test(self, config: Dict[str, Any]) -> bool:
+        """Connectivity test against Jellyfin."""
+        if not await self.validate_config(config):
+            return False
+
+        base_url = str(config.get("base_url", "")).rstrip("/")
+        api_key = str(config.get("api_key", ""))
+        info_url = f"{base_url}/System/Info"
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+                resp = await client.get(info_url, headers={"X-Emby-Token": api_key})
+                if resp.status_code // 100 != 2:
+                    self._logger.warning(
+                        "jellyfin_test_non_2xx | url=%s status=%s", info_url, resp.status_code
+                    )
+                    return False
+                data: Dict[str, Any] = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            self._logger.warning(
+                "jellyfin_test_error | url=%s error=%s", info_url, exc
+            )
+            return False
+
+        return isinstance(data, dict) and bool(data.get("Version"))
+
+    async def backup(self, context: BackupContext) -> Dict[str, Any]:
+        meta = context.metadata or {}
+        target_slug = meta.get("target_slug") or str(context.target_id)
+        today = datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d")
+
+        base_dir = os.path.join(BACKUP_BASE, target_slug, today)
+        os.makedirs(base_dir, exist_ok=True)
+
+        ts = datetime.now(timezone.utc).astimezone().strftime("%Y%m%dT%H%M%S")
+        artifact_path = os.path.join(base_dir, f"jellyfin-backup-{ts}.zip")
+
+        cfg = getattr(context, "config", {}) or {}
+        base_url = str(cfg.get("base_url", "")).rstrip("/")
+        api_key = cfg.get("api_key")
+        if not base_url or not api_key:
+            raise ValueError("Jellyfin config must include base_url and api_key")
+
+        backup_url = f"{base_url}/Backup/Archive"
+        headers = {
+            "X-Emby-Token": str(api_key),
+            "Accept": "application/zip, application/octet-stream",
+        }
+        self._logger.info(
+            "jellyfin_backup_start | job_id=%s target_id=%s target_slug=%s url=%s artifact=%s",
+            context.job_id,
+            context.target_id,
+            target_slug,
+            backup_url,
+            artifact_path,
+        )
+        try:
+            async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+                resp = await client.get(backup_url, headers=headers)
+                self._logger.info(
+                    "jellyfin_backup_response | job_id=%s target_id=%s status=%s bytes=%s",
+                    context.job_id,
+                    context.target_id,
+                    resp.status_code,
+                    len(resp.content or b""),
+                )
+                resp.raise_for_status()
+                content = resp.content
+        except httpx.HTTPError as exc:
+            self._logger.error(
+                "jellyfin_backup_http_error | job_id=%s target_id=%s error=%s",
+                context.job_id,
+                context.target_id,
+                str(exc),
+            )
+            raise
+
+        if not content:
+            raise RuntimeError("Jellyfin backup returned no content")
+
+        with open(artifact_path, "wb") as f:
+            f.write(content)
+        self._logger.info(
+            "jellyfin_backup_success | job_id=%s target_id=%s artifact=%s size_bytes=%s",
+            context.job_id,
+            context.target_id,
+            artifact_path,
+            len(content),
+        )
+
+        return {"artifact_path": artifact_path}
+
+    async def restore(self, context: BackupContext) -> Dict[str, Any]:  # pragma: no cover - not implemented
+        return {"status": "not_implemented"}
+
+    async def get_status(self, context: BackupContext) -> Dict[str, Any]:  # pragma: no cover - trivial
+        return {"status": "ok"}

--- a/backend/app/plugins/jellyfin/schema.json
+++ b/backend/app/plugins/jellyfin/schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "required": ["base_url", "api_key"],
+  "properties": {
+    "base_url": {"type": "string", "format": "uri", "title": "Base URL", "default": "http://jellyfin.local"},
+    "api_key": {"type": "string", "title": "API Key", "default": "your_api_key"}
+  }
+}

--- a/backend/tests/test_plugin_jellyfin.py
+++ b/backend/tests/test_plugin_jellyfin.py
@@ -1,0 +1,57 @@
+import os
+import httpx
+import pytest
+
+from app.core.plugins.base import BackupContext
+from app.plugins.jellyfin import JellyfinPlugin
+import app.plugins.jellyfin.plugin as jellyfin_module
+
+
+@pytest.mark.asyncio
+async def test_test_returns_true(monkeypatch):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/System/Info"):
+            return httpx.Response(200, json={"Version": "10.8.0"})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    orig_client = httpx.AsyncClient
+
+    def _client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return orig_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _client)
+
+    plugin = JellyfinPlugin(name="jellyfin")
+    ok = await plugin.test({"base_url": "http://example.local", "api_key": "k"})
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_backup_writes_artifact(tmp_path, monkeypatch):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/Backup/Archive"):
+            return httpx.Response(200, content=b"data")
+        return httpx.Response(200, json={"Version": "10.8.0"})
+
+    transport = httpx.MockTransport(handler)
+    orig_client = httpx.AsyncClient
+
+    def _client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return orig_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _client)
+    monkeypatch.setattr(jellyfin_module, "BACKUP_BASE", str(tmp_path))
+
+    plugin = JellyfinPlugin(name="jellyfin")
+    ctx = BackupContext(
+        job_id="1",
+        target_id="1",
+        config={"base_url": "http://example.local", "api_key": "k"},
+        metadata={"target_slug": "test"},
+    )
+    result = await plugin.backup(ctx)
+    artifact_path = result.get("artifact_path")
+    assert artifact_path and os.path.isabs(artifact_path) and os.path.exists(artifact_path)


### PR DESCRIPTION
## Summary
- add Jellyfin backup plugin utilizing Jellyfin Backup API
- define schema and tests for Jellyfin plugin

## Testing
- `cd backend && PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fb242898832699b5e4cbea742128