### PR TITLE
test: make Gitea dump fixture deterministic

### DIFF
--- a/backend/tests/plugins/test_gitea_plugin.py
+++ b/backend/tests/plugins/test_gitea_plugin.py
@@ -303,6 +303,7 @@ async def test_backup_stops_dumps_streams_and_restarts_gitea(
 ) -> None:
     requests: list[tuple[str, str]] = []
     running = True
+    expected_dump = _gitea_dump_zip()
 
     async def handler(request: httpx.Request) -> httpx.Response:
         nonlocal running
@@ -338,7 +339,7 @@ async def test_backup_stops_dumps_streams_and_restarts_gitea(
             if path == "/tmp/gitea-dump.zip":
                 return httpx.Response(
                     200,
-                    content=_docker_file_archive("gitea-dump.zip", _gitea_dump_zip()),
+                    content=_docker_file_archive("gitea-dump.zip", expected_dump),
                 )
         if request.method == "POST" and request.url.path.endswith("/stop"):
             running = False
@@ -401,7 +402,7 @@ async def test_backup_stops_dumps_streams_and_restarts_gitea(
 
     artifact_path = Path(result["artifact_path"])
     assert artifact_path.is_file()
-    assert artifact_path.read_bytes() == _gitea_dump_zip()
+    assert artifact_path.read_bytes() == expected_dump
     sidecar = read_backup_sidecar(str(artifact_path))
     assert sidecar is not None
     assert sidecar["plugin_name"] == "gitea"


### PR DESCRIPTION
## Summary

- generate the synthetic Gitea dump ZIP once per test
- reuse the exact fixture bytes for the mocked Docker response and artifact assertion
- remove the minute-boundary ZIP timestamp race seen in CI run 32447604602

## Verification

- targeted Gitea backup test: 1 passed
- Black: passed
- isort: passed
- git diff --check: passed